### PR TITLE
Update to make the service.consul tld definable without changing current behavior…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ consul_srv.mock("euclid")
 ```
 
 This will set `consul_srv` to serve a mocked service handler when `service("euclid")` is called, bypassing any calls to a consul agent.
+
+
+By default `consul_srv` looks at the `service.consul` "TLD" for service discovery/resolution.  You can modify this, for example for cross Datacenter Resolution with:
+
+```
+import consul_srv
+consul_srv.AGENT_DC = 'service.remotedatacenter.consul'
+```

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -16,10 +16,11 @@ class Resolver(Resolver):
     method. Takes the address and optional port of a DNS server.
     """
 
-    def __init__(self, server_address, port=8600):
+    def __init__(self, server_address, port=8600, consul_domain='service.consul'):
         super(Resolver, self).__init__()
         self.nameservers = [server_address]
         self.nameserver_ports = {server_address: port}
+        self.consul_domain = consul_domain
 
     def _get_host(self, answer):
         for resource in answer.response.additional:
@@ -41,7 +42,7 @@ class Resolver(Resolver):
         Query this resolver's nameserver for the name consul service. Returns a
         named host/port tuple from the first element of the response.
         """
-        domain_name = "{}.service.consul".format(resource)
+        domain_name = "{}.{}".format(resource, self.consul_domain)
         # Get the host from the ADDITIONAL section
         answer = self.query(domain_name, "SRV", tcp=True)
 


### PR DESCRIPTION
Making the port and consul TLD ('service.consul') definable when initializing the class.  Purpose is to allow the definition of a separate DC in the tld.  Consul Service via DNS supports the "SERVICENAME.service.[datacenter.]consul" format.  

Also wanted to maintain the current way this class is used so there is backwards compatibility.

 - [ ] needs python person to say this is ok way to do it


Background:

This wrapper around consul was hard coded to use "service.consul" which prevents using the DNS service resolution/discovery for other consul data centers.  Basically making this change to allow the configuration and connection to dns service discovery via the extended consul DNS datacenter specification, `SERVICENAME.service.[datacenter.]consul` 

This allows the resolution of remote DC services.  

Clubhouse Link:
https://app.clubhouse.io/makespace/story/43137/modify-consul-srv-to-allow-lookup-of-a-dc-in-a-consul-dns-query
