### PR TITLE
BruteForceFix for DNS Timeouts V0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ By default `consul_srv` looks at the `service.consul` "TLD" for service discover
 import consul_srv
 consul_srv.AGENT_DC = 'service.remotedatacenter.consul'
 ```
+
+
+## Build and deploy
+
+I've created a helper directory called build.  This assumes you can SSH to baikonur because it populates `PIPY_URL` from there.
+
+ - upate the `setup.py` for version number
+
+ - `./build_helper/image_build.sh` quickly builds a python 2.7 container with current source
+
+ - `./build_helper/image_run.sh` runs that container
+
+now we're in a python 2.7 shell we can build the package with
+
+ - `python setup.py bdist_wheel --universal`
+
+ - `curl -F package=@dist/consul_srv-*{version}*-py2.py3-none-any.whl $PYPI_URL`

--- a/build_helper/Dockerfile
+++ b/build_helper/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:2.7-slim
+
+ARG PYPI_URL
+
+ENV APP_HOME=/app
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo "alias dir='ls -alh --color'" >> /etc/bash.bashrc && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends bash curl busybox dumb-init && \
+    pip install pipenv
+
+ENV PYPI_URL=${PYPI_URL}
+
+ENV PIPENV_VENV_IN_PROJECT=1 \
+    PYTHONUNBUFFERED=1
+
+COPY ./build_helper/entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+
+COPY . /app
+
+WORKDIR ${APP_HOME}
+EXPOSE 8080
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["shell"]

--- a/build_helper/entrypoint.sh
+++ b/build_helper/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/dumb-init /bin/bash
+# ----------------------------------------------------------------------------
+# entrypoint for container
+# ----------------------------------------------------------------------------
+set -e
+
+HOST_IP=`/bin/grep $HOSTNAME /etc/hosts | /usr/bin/cut -f1`
+export HOST_IP=${HOST_IP}
+echo
+echo "container started with ip: ${HOST_IP}..."
+echo
+for script in /container-init.d/*; do
+	case "$script" in
+		*.sh)     echo "... running $script"; . "$script" ;;
+		*)        echo "... ignoring $script" ;;
+	esac
+	echo
+done
+
+if [ "$1" == "shell" ]; then
+	echo "starting /usr/local/bin/pipenv shell..."
+	/usr/local/bin/pipenv shell
+else
+	echo "Running something else ($@)"
+	exec "$@"
+fi

--- a/build_helper/image_build.sh
+++ b/build_helper/image_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+PYPI_URL=`ssh ubuntu@baikonur.mksp.co consul kv get pypi/index_url`
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    export DOCKER_BUILDKIT=1
+fi
+
+docker build \
+    --build-arg PYPI_URL=${PYPI_URL} \
+    -f ./build_helper/Dockerfile \
+    -t consul_srv_builder .

--- a/build_helper/image_run.sh
+++ b/build_helper/image_run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# -v $(pwd):/app \
+
+docker run \
+    -it consul_srv_builder

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -3,12 +3,10 @@ Simple wrapper around dnspython to query a Consul agent over its DNS port and
 extract ip address/port information.
 """
 from collections import namedtuple
-
 from dns import rdatatype
 from dns.resolver import Resolver
 
 SRV = namedtuple("SRV", ["host", "port"])
-
 
 class Resolver(Resolver):
     """
@@ -21,6 +19,12 @@ class Resolver(Resolver):
         self.nameservers = [server_address]
         self.nameserver_ports = {server_address: port}
         self.consul_domain = consul_domain
+        # timeout = The number of seconds to wait for a response from a server, before timing out.
+        # lifetime = The total number of seconds to spend trying to get an answer to the question.
+        # max_lookup = [ours] Total number of looping loopups to do
+        self.timeout = 2
+        self.lifetime = 4
+        self.max_lookup = 5
 
     def _get_host(self, answer):
         for resource in answer.response.additional:
@@ -37,16 +41,26 @@ class Resolver(Resolver):
 
         raise ValueError("No port information.")
 
+    def get_service(self, resource, count=0):
+        domain_name = "{}.{}".format(resource, self.consul_domain)
+        try:
+            answer = self.query(domain_name, "SRV", tcp=True)
+        except self.Timeout:
+            if(count<self.max_lookup):
+                count = count + 1
+                answer = self.get_service(resource, count)
+            else:
+                raise self.Timeout
+
+        return answer
+
     def srv(self, resource):
         """
         Query this resolver's nameserver for the name consul service. Returns a
         named host/port tuple from the first element of the response.
         """
-        domain_name = "{}.{}".format(resource, self.consul_domain)
         # Get the host from the ADDITIONAL section
-        answer = self.query(domain_name, "SRV", tcp=True)
-
+        answer = self.get_service(resource)
         host = self._get_host(answer)
         port = self._get_port(answer)
-
         return SRV(host, port)

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -22,8 +22,8 @@ class Resolver(Resolver):
         # timeout = The number of seconds to wait for a response from a server, before timing out.
         # lifetime = The total number of seconds to spend trying to get an answer to the question.
         # max_lookup = [ours] Total number of looping loopups to do
-        self.timeout = 2
-        self.lifetime = 4
+        self.timeout = 1
+        self.lifetime = 2
         self.max_lookup = 5
 
     def _get_host(self, answer):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='consul_srv',
-    version='0.5.2',
+    version='0.5.3',
     description='Consul SRV convenience module',
     author='Zach Smith',
     author_email='zach.smith@makespace.com',


### PR DESCRIPTION
An attempt to bruteforce fix these DNS timeout issues.

From PythonDNS: 
Resolver.timeout = The number of seconds to wait for a response from a server, before timing out.
Resolver.lifetime = The total number of seconds to spend trying to get an answer to the question.

First; set timeout for DNS for something fast, default is 30sec, changed to 1sec.  We're dealing with local DNS and it should be practically instant.
Second; set lifetime for DNS query to be also fast but slower the timeout: 2sec.  Again we're dealing with localDNS.

Third; add a brute force loop.  Try the above X number of times before we give up.  I choose 5 times abritrarily

