### PR TITLE
feature: handle cnames, random ip from list when list, better handling of host.docker.local

### DIFF
--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -71,6 +71,9 @@ class Service(object):
     
     def resolve(self, service_name):
         server_address = AGENT_URI
+        # because of the special case involved with passing host.docker.internal to AGENT_URI
+        # we have to resolve this to the ip address as this can/will be different for each docker
+        # environment.
         if(server_address=='host.docker.internal'):
             logging.debug('consul_srv: SPECIAL CASE FOR AGENT_URI = {}'.format(server_address))
             theresolver = dns.resolver.Resolver()

--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -68,7 +68,7 @@ class Service(object):
     MOCK_SERVICES = {"__all__": False}
     SERVICE_MAP = {"default": ConsulClient}
     MOCKED_SERVICE_MAP = {}
-    
+
     def resolve(self, service_name):
         server_address = AGENT_URI
         # because of the special case involved with passing host.docker.internal to AGENT_URI

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -61,10 +61,6 @@ class Resolver(Resolver):
     def _get_host(self, answer):
         # changing this functionality from the non-compliant get info from the additional
         # section, to the more compliant do a lookup from host provided by SRV record
-        #for resource in answer.response.additional:
-        #    for record in resource.items:
-        #        if record.rdtype == rdatatype.A:
-        #            return record.address
         for resource in answer:
             if resource.rdtype == rdatatype.SRV:
                 hostip = self._lookup_host(resource.target)

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -5,6 +5,7 @@ extract ip address/port information.
 from collections import namedtuple
 from dns import rdatatype
 from dns.resolver import Resolver
+import dns
 import time
 import random
 import logging
@@ -31,12 +32,34 @@ class Resolver(Resolver):
         self.lifetime = 4
         self.max_lookup = 6
 
-    def _get_host(self, answer):
-        for resource in answer.response.additional:
-            for record in resource.items:
-                if record.rdtype == rdatatype.A:
-                    return record.address
+    def _lookup_host(self, hostname):
+        a = hostname.to_text().rstrip('.')
+        if 'consul' in a:
+            logging.debug('consul_srv: lookup "{}" in consul'.format(a))
+            c=self.query(hostname, "A", tcp=True)
+        else:
+            logging.debug('consul_srv: lookup for "{}" in local dns'.format(a))
+            b = dns.resolver.Resolver()
+            c = b.query(a, 'A', tcp=True)
+        d=False
+        iplist=[]
+        for ipval in c:
+            d=ipval.to_text()
+            iplist.append(d)
+            logging.debug('consul_srv: lookup found {}'.format(d))
+        return iplist[random.randint(0,len(iplist)-1)]
 
+    def _get_host(self, answer):
+        #for resource in answer.response.additional:
+        #    for record in resource.items:
+        #        if record.rdtype == rdatatype.A:
+        #            return record.address
+        for resource in answer:
+            if resource.rdtype == rdatatype.SRV:
+                a = self._lookup_host(resource.target)
+                if a is not False:
+                    logging.debug('consul_srv: going with {}'.format(a))
+                    return a
         raise ValueError("No host information.")
 
     def _get_port(self, answer):
@@ -53,7 +76,7 @@ class Resolver(Resolver):
         except:
             if(count<self.max_lookup):
                 count = count + 1
-                logging.debug('consul_srv: exception, sleeping random 0-1 sec to try again, try {} of {}\n'.format(count, self.max_lookup))
+                logging.debug('consul_srv: exception, sleeping random 0-1 sec to try again, try {} of {}'.format(count, self.max_lookup))
                 time.sleep(random.random())
                 answer = self.get_service(resource, count)
             else:
@@ -67,10 +90,10 @@ class Resolver(Resolver):
         named host/port tuple from the first element of the response.
         """
         # Get the host from the ADDITIONAL section
-        logging.debug('consul_srv: asked to lookup {} from {}:{}\n'.format( resource, self.consul_server, self.consul_port ))
+        logging.debug('consul_srv: asked to lookup {} from {}:{}'.format( resource, self.consul_server, self.consul_port ))
 
         answer = self.get_service(resource)
         host = self._get_host(answer)
         port = self._get_port(answer)
-        logging.debug('consul_srv: recieved answer for {} as {}:{}\n'.format( resource, host, port ))
+        logging.debug('consul_srv: recieved answer for {} as {}:{}'.format( resource, host, port ))
         return SRV(host, port)

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -33,40 +33,50 @@ class Resolver(Resolver):
         self.max_lookup = 6
 
     def _lookup_host(self, hostname):
-        a = hostname.to_text().rstrip('.')
-        if 'consul' in a:
-            logging.debug('consul_srv: lookup "{}" in consul'.format(a))
-            c=self.query(hostname, "A", tcp=True)
+        # quick resolver for a hostname with special case if it's a consul hostname
+        # for best results, we remove the trailing period and make sure it is a string
+        # in a couple cases this comes in as type "NAME" whatever that is
+        thehostname = hostname.to_text().rstrip('.')
+        # this should probably be "ends with consul." which would be more accurate 
+        if 'consul' in thehostname:
+            # if consul is in the host name we ask the consul DNS which we are already
+            # configured for...
+            logging.debug('consul_srv: lookup "{}" in consul dns'.format(thehostname))
+            theanswer=self.query(hostname, "A", tcp=True)
         else:
-            logging.debug('consul_srv: lookup for "{}" in local dns'.format(a))
-            b = dns.resolver.Resolver()
-            c = b.query(a, 'A', tcp=True)
-        d=False
+            # otherwise we ask for a new dns.resolver.Resolver which we have not
+            # overridden the nameserver list (comes from host) to resolve the hostname
+            logging.debug('consul_srv: lookup for "{}" in local dns'.format(thehostname))
+            theresolver = dns.resolver.Resolver()
+            theanswer = theresolver.query(thehostname, 'A', tcp=True)
         iplist=[]
-        for ipval in c:
-            d=ipval.to_text()
-            iplist.append(d)
-            logging.debug('consul_srv: lookup found {}'.format(d))
-        return iplist[random.randint(0,len(iplist)-1)]
+        for ipval in theanswer:
+            foundip=ipval.to_text()
+            iplist.append(foundip)
+            logging.debug('consul_srv: lookup found {}'.format(foundip))
+        if len(iplist) > 0:
+            return iplist[random.randint(0,len(iplist)-1)]
+        raise ValueError("Lookup did not return information.")
 
     def _get_host(self, answer):
+        # changing this functionality from the non-compliant get info from the additional
+        # section, to the more compliant do a lookup from host provided by SRV record
         #for resource in answer.response.additional:
         #    for record in resource.items:
         #        if record.rdtype == rdatatype.A:
         #            return record.address
         for resource in answer:
             if resource.rdtype == rdatatype.SRV:
-                a = self._lookup_host(resource.target)
-                if a is not False:
-                    logging.debug('consul_srv: going with {}'.format(a))
-                    return a
+                hostip = self._lookup_host(resource.target)
+                if hostip is not False:
+                    logging.debug('consul_srv: going with {}'.format(hostip))
+                    return hostip
         raise ValueError("No host information.")
 
     def _get_port(self, answer):
         for resource in answer:
             if resource.rdtype == rdatatype.SRV:
                 return resource.port
-
         raise ValueError("No port information.")
 
     def get_service(self, resource, count=0):
@@ -89,9 +99,7 @@ class Resolver(Resolver):
         Query this resolver's nameserver for the name consul service. Returns a
         named host/port tuple from the first element of the response.
         """
-        # Get the host from the ADDITIONAL section
         logging.debug('consul_srv: asked to lookup {} from {}:{}'.format( resource, self.consul_server, self.consul_port ))
-
         answer = self.get_service(resource)
         host = self._get_host(answer)
         port = self._get_port(answer)


### PR DESCRIPTION
Still need to set up for new version to push to gemfurry

Goals here:

First, the DNS package doesn't like using "names" for nameserver (go figure) so we need to be able to resolve the special case 'host.docker.internal' to an IP and use that in the nameserver list when the override AGENT_URI contains that.

Second, currently consul_srv only worked when consul responded to a SRV request that contained an IP in the "address" field.  Since it's part of the spec that consul can also support a host name here, we need to support that.  

Third, we need to not change the lookup behavior much because of the non threaded, synchronous nature of python and dns.  (this is a known problem and why there is the weird loop with random sleeps, a brute force method to work through the issue)

Some notes:

Behavior when CONSUL service is registered with an IP:
SRV request for an existing service addrservice registered with the ip of 4.3.2.1 returns:
```
addrservice.service.consul. 0	IN	SRV	1 1 443 04030201.addr.dc1.consul.
```
`04030201.addr.dc1.consul.` is an internal consul record that we make a standard query for against consul returning:
```
04030201.addr.dc1.consul. 0	IN	A	4.3.2.1
```
so the returned address should be 4.3.2.1

SRV request for an existing service hostservice registered with the hostname of hostservice.mksp.co:
```
hostservice.service.consul. 0 IN	SRV	1 1 443 hostservice.mksp.co.
```
`hostservice.mksp.co.` is an EXTERNAL host name that returns when queried against consul:
NXDOMAIN - host doesn't exist
but when we query against the "normal" dns (no consul overrides) we get:
```
hostservice.mksp.co.	77	IN	A	52.71.81.212
hostservice.mksp.co.	77	IN	A	34.231.55.73
hostservice.mksp.co.	77	IN	A	35.169.11.217
```
so the returned address should be one of the three at random



This changes the original behavior a bit which originally depended on using the additional section of the SRV request to get the IP

FULL SRV lookups for reference:
SRV addrservice asked against consul:
```
;; QUESTION SECTION:
;addrservice.service.consul.	IN	SRV

;; ANSWER SECTION:
addrservice.service.consul. 0	IN	SRV	1 1 443 04030201.addr.dc1.consul.

;; ADDITIONAL SECTION:
04030201.addr.dc1.consul. 0	IN	A	4.3.2.1
172.17.0.5.node.dc1.consul. 0	IN	TXT	"consul-network-segment="
```

SRV hostservice asked against consul:
```
;; QUESTION SECTION:
;hostservice.service.consul. IN	SRV

;; ANSWER SECTION:
hostservice.service.consul. 0 IN	SRV	1 1 443 hostservice.mksp.co.

;; ADDITIONAL SECTION:
172.17.0.5.node.dc1.consul. 0	IN	TXT	"consul-network-segment="
```
RESOLV request asked against not consul:
```
;; QUESTION SECTION:
;hostservice.mksp.co.		IN	A

;; ANSWER SECTION:
hostservice.mksp.co.	77	IN	A	52.71.81.212
hostservice.mksp.co.	77	IN	A	34.231.55.73
hostservice.mksp.co.	77	IN	A	35.169.11.217
```
