### PR TITLE
Consul-Srv refactor: Moving DNS request to async_dns and asyncio

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ I've created a helper directory called build. You will need to populate `PIPY_UR
 
  - `./build_helper/image_run.sh` runs that container
 
-now we're in a python 2.7 shell we can build the package with
+now we're in a python 3.7 shell we can build the package with
 
  - `python setup.py bdist_wheel --universal`
 

--- a/build_helper/Dockerfile
+++ b/build_helper/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:3.7-slim
 
 ARG PYPI_URL
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 setup(
     name='consul_srv',
-    version='0.5.5',
+    version='0.6.0',
     description='Consul SRV convenience module',
     author='Zach Smith',
     author_email='zach.smith@makespace.com',
     license='BSD3',
     packages=['consul_srv'],
-    install_requires=["dnspython", "requests"])
+    install_requires=["dnspython", "requests", "async_dns"])

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+# small web server that instruments "GET" but then serves up files
+# to server files with zero lines of code,  do
+#
+#   python -m http.server 8080     # python 3
+#
+# or
+#
+#   python -m SimpleHTTPServer 8080 # python 2
+#
+# Shamelessly snarfed from Gary Robinson
+#    http://www.garyrobinson.net/2004/03/one_line_python.html
+#
+import http.server
+import socketserver
+import consul_srv
+from http import HTTPStatus
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        consul_srv.AGENT_URI = "host.docker.internal"
+        heimdall = consul_srv.service("heimdall-staging", "https")
+        self.send_response(HTTPStatus.OK)
+        self.end_headers()
+        self.wfile.write(b'STATUS OK')
+
+print("starting server...")
+httpd = socketserver.TCPServer(('', 8080), Handler)
+httpd.serve_forever()


### PR DESCRIPTION
## What does this PR do?

## How can I test it?

1. Get the `mksp-compose` repo, and set up the services:

    ```bash
    make resources_start
    make consul_import
    ```

2. Checkout this branch
3. Build the image:

    ```bash
    ./build_helper/image_build.sh
    ```
    
4. Run the image. You get logged in into a Python 3 shell.

    ```bash
    ./build_helper/image_run.sh
    ```
    
5. Run the following commands to install dependencies and prepare to run the consul_srv:

    ```bash
    python setup.py bdist_wheel --universal
    pip install .
    python
    ```
    
6. You can now check the DNS request returned the right data by running this commands:

    ```python
    import consul_srv
    consul_srv.AGENT_URI = "host.docker.internal"
    heimdall = consul_srv.service("heimdall-staging", "https")
    heimdall._path("/status/data.json")
    ```
    
    You should get an output like `'https://35.169.11.217:443/status/data.json'`.

## Any relevant Ticket?
:ticket: [Consul Srv refactor of resolver class as [sc-69590]](https://app.shortcut.com/makespace/story/69590/consul-srv-refactor-of-resolver-class-as-a-poc)

## Any extra or background information?