### PR TITLE
Consul_srv refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ I've created a helper directory called build. You will need to populate `PIPY_UR
 
  - `./build_helper/image_run.sh` runs that container
 
-now we're in a python 2.7 shell we can build the package with
+now we're in a python 3.7 shell we can build the package with
 
  - `python setup.py bdist_wheel --universal`
 

--- a/build_helper/Dockerfile
+++ b/build_helper/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:3.7-slim
 
 ARG PYPI_URL
 

--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -2,9 +2,9 @@ import requests
 import dns
 import logging
 
+from dns.resolver import Resolver
 from collections import namedtuple
 
-from dns.resolver import Resolver
 from . import query
 
 __all__ = ["service", "register", "mock", "AGENT_URI"]
@@ -79,7 +79,7 @@ class Service(object):
         if(server_address=='host.docker.internal'):
             if self.DOCKER_HOST == None:
                 logging.debug('consul_srv: SPECIAL CASE FOR AGENT_URI = {}'.format(server_address))
-                theresolver = dns.resolver.Resolver()
+                theresolver = Resolver() # dns.resolver.Resolver
                 try:
                     answer = theresolver.query('{}'.format(server_address))
                 except DNSException as e:
@@ -146,9 +146,7 @@ class Service(object):
 
         return service
 
-
 service = Service()
-
 
 def register(service_name, handler, mock_handler=None):
     """
@@ -157,7 +155,6 @@ def register(service_name, handler, mock_handler=None):
     service.SERVICE_MAP[service_name] = handler
     if mock_handler is not None:
         service.MOCKED_SERVICE_MAP[service_name] = mock_handler
-
 
 def mock(service_name, should_mock=True, mock_handler=None):
     """

--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -1,8 +1,8 @@
 import requests
-import dns
 import logging
 
 from dns.resolver import Resolver
+from dns.exception import DNSException
 from collections import namedtuple
 
 from . import query

--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -12,6 +12,7 @@ __all__ = ["service", "register", "mock", "AGENT_URI"]
 AGENT_URI = "127.0.0.1"
 AGENT_PORT = 8600
 AGENT_DC = "service.consul"
+AGENT_CLIENT_PORT = 8500
 
 TeeConfig = namedtuple('TeeConfig', 'serv_original serv_experimental max_delta fore_service')
 DEFAULT_TEE_SERVICE = 'fore'
@@ -91,7 +92,7 @@ class Service(object):
                 self.DOCKER_HOST = server_address
             else:
                 server_address = self.DOCKER_HOST
-        resolver = query.Resolver(server_address = server_address, port=AGENT_PORT, consul_domain=AGENT_DC)
+        resolver = query.Resolver(server_address = server_address, port=AGENT_PORT, consul_domain=AGENT_DC, client_port=AGENT_CLIENT_PORT)
         return resolver.srv(service_name)
 
     def __call__(self, service_name, *args, **kwargs):

--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -1,7 +1,10 @@
 import requests
+import dns
+import logging
 
 from collections import namedtuple
 
+from dns.resolver import Resolver
 from . import query
 
 __all__ = ["service", "register", "mock", "AGENT_URI"]
@@ -66,9 +69,29 @@ class Service(object):
     MOCK_SERVICES = {"__all__": False}
     SERVICE_MAP = {"default": ConsulClient}
     MOCKED_SERVICE_MAP = {}
+    DOCKER_HOST = None
 
     def resolve(self, service_name):
-        resolver = query.Resolver(AGENT_URI, AGENT_PORT, AGENT_DC)
+        server_address = AGENT_URI
+        # because of the special case involved with passing host.docker.internal to AGENT_URI
+        # we have to resolve this to the ip address as this can/will be different for each docker
+        # environment.
+        if(server_address=='host.docker.internal'):
+            if self.DOCKER_HOST == None:
+                logging.debug('consul_srv: SPECIAL CASE FOR AGENT_URI = {}'.format(server_address))
+                theresolver = dns.resolver.Resolver()
+                try:
+                    answer = theresolver.query('{}'.format(server_address))
+                except DNSException as e:
+                    logging.exception('An exception occurred while trying to find "host.docker.internal" IP.')
+                    logging.exception('Exception details: {}'.format(e))
+                for ipval in answer:
+                    server_address=ipval.to_text()
+                logging.debug('consul_srv: RESOLVED AGENT_URI = "{}"'.format(server_address))
+                self.DOCKER_HOST = server_address
+            else:
+                server_address = self.DOCKER_HOST
+        resolver = query.Resolver(server_address = server_address, port=AGENT_PORT, consul_domain=AGENT_DC)
         return resolver.srv(service_name)
 
     def __call__(self, service_name, *args, **kwargs):

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -48,9 +48,8 @@ class Resolver(aiodns.DNSResolver):
         return await self.query(name, query_type)
 
     def _get_host(self, answer):
-        logging.debug('Got these: {}'.format(answer))
         for record in answer[1]: 
-            logging.debug('Looking for host at {}'.format(record))
+            logging.debug('consul_srv: looking for host at {}'.format(record))
             if type(record) == pycares.ares_query_a_result:
                 return record.host
 
@@ -58,7 +57,7 @@ class Resolver(aiodns.DNSResolver):
 
     def _get_port(self, answer):
         for record in answer[0]: 
-            logging.debug('Looking for port at {}'.format(record))
+            logging.debug('consul_srv: looking for port at {}'.format(record))
             if type(record) == pycares.ares_query_srv_result:
                 return record.port
 
@@ -67,6 +66,7 @@ class Resolver(aiodns.DNSResolver):
     def get_service(self, resource, count=0):
         domain_name = "{}.{}".format(resource, self.consul_domain)
         try:
+            logging.debug('consul_srv: requesting entries for {}'.format(domain_name))
             coroSRV = self.runQuery(domain_name, 'SRV')
             coroA = self.runQuery(domain_name, 'A')
             answer = self.loop.run_until_complete(asyncio.gather(
@@ -94,5 +94,5 @@ class Resolver(aiodns.DNSResolver):
         answer = self.get_service(resource)
         host = self._get_host(answer)
         port = self._get_port(answer)
-        logging.debug('consul_srv: recieved answer for {} as {}:{}\n'.format( resource, host, port ))
+        logging.info('consul_srv: recieved answer for {} as {}:{}\n'.format( resource, host, port ))
         return SRV(host, port)

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -11,6 +11,7 @@ from typing import (
 
 import asyncio
 import aiodns
+import consul
 import pycares
 import time
 import random
@@ -27,13 +28,14 @@ class Resolver(aiodns.DNSResolver):
     def __init__(self, server_address: Optional[str] = None,
                  loop: Optional[asyncio.AbstractEventLoop] = None,
                  port = 53,
-                 timeout=2.0,
+                 client_port = 8500,
+                 timeout=1,
                  consul_domain='service.consul',
                  **kwargs: Any) -> None:
         self.loop = loop or asyncio.get_event_loop()
         assert self.loop is not None
         kwargs.pop('sock_state_cb', None)
-        self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb, timeout=timeout, udp_port=port, **kwargs)
+        self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb, tries=1, timeout=timeout, udp_port=port, **kwargs)
         if server_address:
             self.nameservers = [server_address]
         self._read_fds = set() # type: Set[int]
@@ -43,6 +45,7 @@ class Resolver(aiodns.DNSResolver):
         self.consul_address = '{}:{}'.format(server_address,port)
         self.consul_domain = consul_domain
         self.max_lookup = 5
+        self.client_port = client_port
 
     async def runQuery(self, name, query_type):
         return await self.query(name, query_type)
@@ -63,24 +66,42 @@ class Resolver(aiodns.DNSResolver):
 
         raise ValueError("No port information.")
 
-    def get_service(self, resource, count=0):
+    def get_service_from_consul(self, resource):
+        logging.debug('consul_srv: running Consul Client query')
+        client = consul.Consul(host=self.nameservers[0], port=self.client_port)
+        service_instances = client.catalog.service(resource)[1]
+        rand_instance = random.randint(0, len(service_instances)-1)
+        service_instance = service_instances[rand_instance]
+        return SRV(service_instance['ServiceAddress'], service_instance['ServicePort'])
+
+    def get_service_from_dns(self, resource):
+        logging.debug('consul_srv: running DNS query')
         domain_name = "{}.{}".format(resource, self.consul_domain)
+        coroSRV = self.runQuery(domain_name, 'SRV')
+        coroA = self.runQuery(domain_name, 'A')
+        answer = self.loop.run_until_complete(asyncio.gather(
+            coroSRV,
+            coroA
+        ))
+        return SRV(self._get_host(answer), self._get_port(answer))
+
+    def get_service(self, resource, count=0):
+        
         try:
-            logging.debug('consul_srv: requesting entries for {}'.format(domain_name))
-            coroSRV = self.runQuery(domain_name, 'SRV')
-            coroA = self.runQuery(domain_name, 'A')
-            answer = self.loop.run_until_complete(asyncio.gather(
-                coroSRV,
-                coroA
-            ))
+            logging.debug('consul_srv: requesting entries for {}'.format(resource))
+            answer = self.get_service_from_dns(resource)
         except:
-            if(count<self.max_lookup):
-                count = count + 1
-                logging.debug('consul_srv: exception, sleeping random 0-1 sec to try again, try {} of {}\n'.format(count, self.max_lookup))
-                time.sleep(random.random())
-                answer = self.get_service(resource, count)
-            else:
-                raise
+            try:
+                logging.debug('consul_srv: something odd happen while running DNS query, falling back to consul client')
+                answer = self.get_service_from_consul(resource)
+            except:
+                if(count<self.max_lookup):
+                    count = count + 1
+                    logging.debug('consul_srv: exception, sleeping random 0-1 sec to try again, try {} of {}\n'.format(count, self.max_lookup))
+                    time.sleep(random.random())
+                    answer = self.get_service(resource, count)
+                else:
+                    raise
         return answer
 
     def srv(self, resource):
@@ -89,10 +110,7 @@ class Resolver(aiodns.DNSResolver):
         named host/port tuple from the first element of the response.
         """
         # Get the host from the ADDITIONAL section
-        logging.debug('consul_srv: asked to lookup {} from {}\n'.format( resource, self.consul_address ))
-
+        logging.debug('consul_srv: asked to lookup {} from {}'.format( resource, self.consul_address ))
         answer = self.get_service(resource)
-        host = self._get_host(answer)
-        port = self._get_port(answer)
-        logging.info('consul_srv: recieved answer for {} as {}:{}\n'.format( resource, host, port ))
-        return SRV(host, port)
+        logging.info('consul_srv: recieved answer for {} as {}\n'.format( resource, answer ))
+        return answer

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -4,52 +4,80 @@ extract ip address/port information.
 """
 from collections import namedtuple
 from dns import rdatatype
-from dns.resolver import Resolver
+from typing import (
+    Any,
+    List,
+    Optional,
+    Set
+)
+
+import asyncio
+import aiodns
+import pycares
 import time
 import random
 import logging
 
 SRV = namedtuple("SRV", ["host", "port"])
 
-class Resolver(Resolver):
+class Resolver(aiodns.DNSResolver):
     """
     Wrapper around the dnspython Resolver class that implements the `srv`
     method. Takes the address and optional port of a DNS server.
     """
 
-    def __init__(self, server_address, port=8600, consul_domain='service.consul'):
-        super(Resolver, self).__init__()
-        self.consul_server = server_address
-        self.consul_port = port
-        self.nameservers = [server_address]
-        self.nameserver_ports = {server_address: port}
+    def __init__(self, server_address: Optional[str] = None,
+                 loop: Optional[asyncio.AbstractEventLoop] = None,
+                 port = 53,
+                 timeout=2.0,
+                 consul_domain='service.consul',
+                 **kwargs: Any) -> None:
+        self.loop = loop or asyncio.get_event_loop()
+        assert self.loop is not None
+        kwargs.pop('sock_state_cb', None)
+        self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb, timeout=timeout, udp_port=port, **kwargs)
+        if server_address:
+            self.nameservers = [server_address]
+        self._read_fds = set() # type: Set[int]
+        self._write_fds = set() # type: Set[int]
+        self._timer = None  # type: Optional[asyncio.TimerHandle]
+
+        self.consul_address = '{}:{}'.format(server_address,port)
         self.consul_domain = consul_domain
-        # timeout = The number of seconds to wait for a response from a server, before timing out.
-        # lifetime = The total number of seconds to spend trying to get an answer to the question.
-        # max_lookup = [ours] Total number of looping loopups to do
-        self.timeout = 2
-        self.lifetime = 4
-        self.max_lookup = 6
+        self.max_lookup = 5
+
+    async def runQuery(self, name, query_type):
+        return await self.query(name, query_type)
+
 
     def _get_host(self, answer):
-        for resource in answer.response.additional:
-            for record in resource.items:
-                if record.rdtype == rdatatype.A:
-                    return record.address
+        for resources in answer:
+            for record in resources: 
+                logging.debug('Looking for host at {}'.format(record))
+                if type(record) == pycares.ares_query_a_result:
+                    return record.host
 
         raise ValueError("No host information.")
 
     def _get_port(self, answer):
-        for resource in answer:
-            if resource.rdtype == rdatatype.SRV:
-                return resource.port
+        for resources in answer:
+            for record in resources: 
+                logging.debug('Looking for port at {}'.format(record))
+                if type(record) == pycares.ares_query_srv_result:
+                    return record.port
 
         raise ValueError("No port information.")
 
     def get_service(self, resource, count=0):
         domain_name = "{}.{}".format(resource, self.consul_domain)
         try:
-            answer = self.query(domain_name, "SRV", tcp=True)
+            #answer = self.runQuery(domain_name, "SRV")
+            coroSRV = self.runQuery(domain_name, 'SRV')
+            coroA = self.runQuery(domain_name, 'A')
+            answer = self.loop.run_until_complete(asyncio.gather(
+                coroSRV,
+                coroA
+            ))
         except:
             if(count<self.max_lookup):
                 count = count + 1
@@ -58,7 +86,6 @@ class Resolver(Resolver):
                 answer = self.get_service(resource, count)
             else:
                 raise
-
         return answer
 
     def srv(self, resource):
@@ -67,7 +94,7 @@ class Resolver(Resolver):
         named host/port tuple from the first element of the response.
         """
         # Get the host from the ADDITIONAL section
-        logging.debug('consul_srv: asked to lookup {} from {}:{}\n'.format( resource, self.consul_server, self.consul_port ))
+        logging.debug('consul_srv: asked to lookup {} from {}\n'.format( resource, self.consul_address ))
 
         answer = self.get_service(resource)
         host = self._get_host(answer)

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 setup(
     name='consul_srv',
-    version='0.5.5',
+    version='0.6.0',
     description='Consul SRV convenience module',
     author='Zach Smith',
     author_email='zach.smith@makespace.com',
     license='BSD3',
     packages=['consul_srv'],
-    install_requires=["dnspython", "requests"])
+    install_requires=["dnspython", "requests", "asyncio", "aiodns"])

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 setup(
     name='consul_srv',
-    version='0.6.0',
+    version='0.7.0',
     description='Consul SRV convenience module',
     author='Zach Smith',
     author_email='zach.smith@makespace.com',
     license='BSD3',
     packages=['consul_srv'],
-    install_requires=["dnspython", "requests", "asyncio", "aiodns"])
+    install_requires=["dnspython", "requests", "asyncio", "aiodns", "python-consul2"])

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+# small web server that instruments "GET" but then serves up files
+# to server files with zero lines of code,  do
+#
+#   python -m http.server 8080     # python 3
+#
+# or
+#
+#   python -m SimpleHTTPServer 8080 # python 2
+#
+# Shamelessly snarfed from Gary Robinson
+#    http://www.garyrobinson.net/2004/03/one_line_python.html
+#
+import http.server
+import socketserver
+import consul_srv
+from http import HTTPStatus
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        consul_srv.AGENT_URI = "host.docker.internal"
+        heimdall = consul_srv.service("heimdall-staging", "https")
+        print("Got path: {}".format(heimdall._path('/path')))
+        self.send_response(HTTPStatus.OK)
+        self.end_headers()
+        self.wfile.write(b'STATUS OK')
+
+print("starting server...")
+httpd = socketserver.TCPServer(('', 8080), Handler)
+try:
+    httpd.serve_forever()
+except KeyboardInterrupt:
+    pass
+finally:
+    print("stoping server...")
+    # Clean-up server (close socket, etc.)
+    httpd.server_close()
+    httpd.shutdown()


### PR DESCRIPTION
## What does this PR do?

The following features/changes were introduce:
* DNS queries are now made using C-Ares and asyncIO libraries, to be able to execute them in parallel and so improving performance (which went from ~35 requests/sec to ~110 request/sec).
* Randomize the IP returned when a service has more than one endpoint available. This actually was achieved by picking the first one returned, since CONSUL return the IPs in deferent order on each call.
* The default setting of the AGENT address now accepts the host "host.docker.internal" as valid now, to add compatibility with local environments.

## How can I test it?

1. Get the `mksp-compose` repo, and set up the services:

    ```bash
    make resources_start
    make consul_import
    ```

2. Checkout this branch
3. Build the image:

    ```bash
    ./build_helper/image_build.sh
    ```
    
4. Run the image. You get logged in into a Python 3 shell.

    ```bash
    ./build_helper/image_run.sh
    ```
    
5. Run the following commands to install dependencies and prepare to run the consul_srv:

    ```bash
    python setup.py bdist_wheel --universal
    pip install .
    python
    ```
    
6. You can now check the DNS request returned the right data by running this commands:

    ```python
    import consul_srv
    consul_srv.AGENT_URI = "host.docker.internal"
    heimdall = consul_srv.service("heimdall-staging", "https")
    heimdall._path("/status/data.json")
    ```
    
    You should get an output like `'https://35.169.11.217:443/status/data.json'`.

## Any relevant Ticket?
:ticket: [Consul Srv refactor of resolver class as [sc-69590]](https://app.shortcut.com/makespace/story/69590/consul-srv-refactor-of-resolver-class-as-a-poc)

## Any extra or background information?