### PR TITLE
Consul client failsafe implementation

### DIFF
--- a/consul_srv/__init__.py
+++ b/consul_srv/__init__.py
@@ -12,6 +12,7 @@ __all__ = ["service", "register", "mock", "AGENT_URI"]
 AGENT_URI = "127.0.0.1"
 AGENT_PORT = 8600
 AGENT_DC = "service.consul"
+AGENT_CLIENT_PORT = 8500
 
 TeeConfig = namedtuple('TeeConfig', 'serv_original serv_experimental max_delta fore_service')
 DEFAULT_TEE_SERVICE = 'fore'
@@ -91,7 +92,7 @@ class Service(object):
                 self.DOCKER_HOST = server_address
             else:
                 server_address = self.DOCKER_HOST
-        resolver = query.Resolver(server_address = server_address, port=AGENT_PORT, consul_domain=AGENT_DC)
+        resolver = query.Resolver(server_address = server_address, port=AGENT_PORT, consul_domain=AGENT_DC, client_port=AGENT_CLIENT_PORT)
         return resolver.srv(service_name)
 
     def __call__(self, service_name, *args, **kwargs):

--- a/consul_srv/query.py
+++ b/consul_srv/query.py
@@ -11,6 +11,7 @@ from typing import (
 
 import asyncio
 import aiodns
+import consul
 import pycares
 import time
 import random
@@ -27,13 +28,14 @@ class Resolver(aiodns.DNSResolver):
     def __init__(self, server_address: Optional[str] = None,
                  loop: Optional[asyncio.AbstractEventLoop] = None,
                  port = 53,
-                 timeout=2.0,
+                 client_port = 8500,
+                 timeout=1,
                  consul_domain='service.consul',
                  **kwargs: Any) -> None:
         self.loop = loop or asyncio.get_event_loop()
         assert self.loop is not None
         kwargs.pop('sock_state_cb', None)
-        self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb, timeout=timeout, udp_port=port, **kwargs)
+        self._channel = pycares.Channel(sock_state_cb=self._sock_state_cb, tries=1, timeout=timeout, udp_port=port, **kwargs)
         if server_address:
             self.nameservers = [server_address]
         self._read_fds = set() # type: Set[int]
@@ -43,6 +45,7 @@ class Resolver(aiodns.DNSResolver):
         self.consul_address = '{}:{}'.format(server_address,port)
         self.consul_domain = consul_domain
         self.max_lookup = 5
+        self.client_port = client_port
 
     async def runQuery(self, name, query_type):
         return await self.query(name, query_type)
@@ -63,24 +66,42 @@ class Resolver(aiodns.DNSResolver):
 
         raise ValueError("No port information.")
 
-    def get_service(self, resource, count=0):
+    def get_service_from_consul(self, resource):
+        logging.debug('consul_srv: running Consul Client query')
+        client = consul.Consul(host=self.nameservers[0], port=self.client_port)
+        service_instances = client.catalog.service(resource)[1]
+        rand_instance = random.randint(0, len(service_instances)-1)
+        service_instance = service_instances[rand_instance]
+        return SRV(service_instance['ServiceAddress'], service_instance['ServicePort'])
+
+    def get_service_from_dns(self, resource):
+        logging.debug('consul_srv: running DNS query')
         domain_name = "{}.{}".format(resource, self.consul_domain)
+        coroSRV = self.runQuery(domain_name, 'SRV')
+        coroA = self.runQuery(domain_name, 'A')
+        answer = self.loop.run_until_complete(asyncio.gather(
+            coroSRV,
+            coroA
+        ))
+        return SRV(self._get_host(answer), self._get_port(answer))
+
+    def get_service(self, resource, count=0):
+        
         try:
-            logging.debug('consul_srv: requesting entries for {}'.format(domain_name))
-            coroSRV = self.runQuery(domain_name, 'SRV')
-            coroA = self.runQuery(domain_name, 'A')
-            answer = self.loop.run_until_complete(asyncio.gather(
-                coroSRV,
-                coroA
-            ))
+            logging.debug('consul_srv: requesting entries for {}'.format(resource))
+            answer = self.get_service_from_dns(resource)
         except:
-            if(count<self.max_lookup):
-                count = count + 1
-                logging.debug('consul_srv: exception, sleeping random 0-1 sec to try again, try {} of {}\n'.format(count, self.max_lookup))
-                time.sleep(random.random())
-                answer = self.get_service(resource, count)
-            else:
-                raise
+            try:
+                logging.debug('consul_srv: something odd happen while running DNS query, falling back to consul client')
+                answer = self.get_service_from_consul(resource)
+            except:
+                if(count<self.max_lookup):
+                    count = count + 1
+                    logging.debug('consul_srv: exception, sleeping random 0-1 sec to try again, try {} of {}\n'.format(count, self.max_lookup))
+                    time.sleep(random.random())
+                    answer = self.get_service(resource, count)
+                else:
+                    raise
         return answer
 
     def srv(self, resource):
@@ -89,10 +110,7 @@ class Resolver(aiodns.DNSResolver):
         named host/port tuple from the first element of the response.
         """
         # Get the host from the ADDITIONAL section
-        logging.debug('consul_srv: asked to lookup {} from {}\n'.format( resource, self.consul_address ))
-
+        logging.debug('consul_srv: asked to lookup {} from {}'.format( resource, self.consul_address ))
         answer = self.get_service(resource)
-        host = self._get_host(answer)
-        port = self._get_port(answer)
-        logging.info('consul_srv: recieved answer for {} as {}:{}\n'.format( resource, host, port ))
-        return SRV(host, port)
+        logging.info('consul_srv: recieved answer for {} as {}\n'.format( resource, answer ))
+        return answer

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 setup(
     name='consul_srv',
-    version='0.6.0',
+    version='0.7.0',
     description='Consul SRV convenience module',
     author='Zach Smith',
     author_email='zach.smith@makespace.com',
     license='BSD3',
     packages=['consul_srv'],
-    install_requires=["dnspython", "requests", "asyncio", "aiodns"])
+    install_requires=["dnspython", "requests", "asyncio", "aiodns", "python-consul2"])


### PR DESCRIPTION
## What does this PR do?

It adds the python-consul2 library (the consul client) as a failsafe option to query consul services with the DNS query fails for some reason.

## How can I test it?

1. Get the `mksp-compose` repo, and set up the services:

    Change the `8600` consul port to any other number on the `docker-compose.yml` file.

    ```bash
    make resources_start
    make consul_import
    ```

2. Checkout this branch
3. Build the image:

    ```bash
    ./build_helper/image_build.sh
    ```
    
4. Run the image. You get logged in into a Python 3 shell.

    ```bash
    ./build_helper/image_run.sh
    ```
    
5. Run the following commands to install dependencies and prepare to run the consul_srv:

    ```bash
    python setup.py bdist_wheel --universal
    pip install .
    python
    ```
    
6. You can now check the DNS request returned the right data by running this commands:

    ```python
    import consul_srv
    consul_srv.AGENT_URI = "host.docker.internal"
    heimdall = consul_srv.service("heimdall-staging", "https")
    heimdall._path("/status/data.json")
    ```
    
    You should get an output like `'https://35.169.11.217:443/status/data.json'`.

## Any relevant Ticket?
:ticket: [Implement python consul2 lib as a failsafe [sc-70017]](https://app.shortcut.com/makespace/story/70017/implement-python-consul2-lib-as-a-failsafe-for-consul-srv-when-dns-queries-fails)

## Any extra or background information?